### PR TITLE
Fixed Patch Operation PrisonLabor

### DIFF
--- a/1.2/Patches/Mizu_Patches_PrisonLabour.xml
+++ b/1.2/Patches/Mizu_Patches_PrisonLabour.xml
@@ -5,7 +5,7 @@
       <li>Prison Labor</li>
     </mods>
     <match Class="PatchOperationInsert">
-      <xpath>Defs/ThinkTreeDef[defName = "PrisonLabor_WorkThinkTree"]//li[@Class = "PrisonLabor.JobGiver_BedTime"]</xpath>
+      <xpath>Defs/ThinkTreeDef[defName = "PrisonLabor_WorkThinkTree"]//li[@Class = "PrisonLabor.Core.AI.JobGivers.JobGiver_BedTime"]</xpath>
       <value>
         <li Class="MizuMod.JobGiver_GetWater_PrisonLabour" />
       </value>


### PR DESCRIPTION
error was : [No Water, No Life (Continued)] Patch operation Verse.PatchOperationFindMod(Prison Labor) failed ;
this modification to the patch seems to fix it and prisoners should be able to "think" of drinking